### PR TITLE
Remove JSON output from TruffleHog arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ runs:
     - name: TruffleHog 🐽 scanning
       uses: trufflesecurity/trufflehog@main
       with:
-        extra_args: --results=verified,unknown --json
+        extra_args: --results=verified,unknown


### PR DESCRIPTION
the json output make the logs too noisy