### PR TITLE
Add trufflehog_exclude_detectors input

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,45 @@ jobs:
            gitleaks_regex_internal_url: ${{ secrets.GITLEAKS_REGEX_INTERNAL_URL }}
 ```
 
+## ⚙️ Inputs
+
+| Input | Required | Default | Purpose |
+|---|---|---|---|
+| `github_token` | yes | — | Token for repository access and comments |
+| `gitleaks_license` | yes | — | Licensed gitleaks |
+| `gitleaks_regex_internal_url` | no | `""` | Regex identifying internal URLs, added to the gitleaks rules |
+| `trufflehog_exclude_detectors` | no | `""` | Comma-separated TruffleHog detectors to disable for this repository |
+
+### Disabling a TruffleHog detector
+
+Some detectors match strings that cannot be credentials in a given repository. The
+clearest example: TruffleHog's `Lob` detector matches `test_` followed by 35 word
+characters — the shape of a Lob test key — so an ordinary Python test name is
+reported as a **verified** credential and fails the build (see issue #44).
+
+Where a provider genuinely does not apply, a repository can turn that detector off
+without weakening the rest of the scan:
+
+```yaml
+- uses: hmcts/secrets-scanner@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    gitleaks_license: ${{ secrets.GITLEAKS_LICENSE }}
+    trufflehog_exclude_detectors: lob
+```
+
+Two deliberate limits:
+
+- **Detector names only.** The input accepts letters, digits, underscores, commas
+  and hyphens, and the action fails if given anything else. That is what stops it
+  becoming a general argument passthrough, through which `--no-verification` or
+  `--results=all` could quietly weaken the gate.
+- **gitleaks is untouched.** Only TruffleHog's detector set changes, so a secret
+  the other scanner would catch is still caught.
+
+Each exclusion is visible in the workflow file and echoed as a notice in the run
+log, so it stays reviewable rather than becoming invisible configuration.
+
 ## 🔄 Keeping Up to Date
 
 This Action centralises improvements so teams benefit automatically from:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
     required: false
     default: ""
     description: Regex to identify internal urls
+  trufflehog_exclude_detectors:
+    required: false
+    default: ""
+    description: >
+      Comma-separated TruffleHog detectors to disable for this repository, e.g.
+      "lob" for a provider it does not use. Affects TruffleHog only; gitleaks is
+      unchanged. Accepts letters, digits, underscores, commas and hyphens only, so
+      this input cannot be used to pass other arguments to the scanner.
 
 runs:
   using: "composite"
@@ -36,7 +44,31 @@ runs:
         GITLEAKS_ENABLE_COMMENTS: "false" # suppress PR comments
         GITLEAKS_ENABLE_SUMMARY:  "false" # suppress Job Summary
 
+    - name: Compose TruffleHog arguments
+      id: trufflehog_args
+      shell: bash
+      env:
+        # Passed through the environment rather than interpolated into the script:
+        # a workflow input reaching a shell directly is a command-injection seam,
+        # and this action is a security control.
+        EXCLUDE_DETECTORS: ${{ inputs.trufflehog_exclude_detectors }}
+      run: |
+        set -euo pipefail
+        args="--results=verified"
+        if [ -n "$EXCLUDE_DETECTORS" ]; then
+          # Detector names only. Without this check a caller could append arbitrary
+          # flags - --no-verification, or --results=all - and weaken the scan
+          # through an input that reads like a narrow one.
+          if ! printf '%s' "$EXCLUDE_DETECTORS" | grep -Eq '^[A-Za-z0-9_,-]+$'; then
+            echo "::error::trufflehog_exclude_detectors must be a comma-separated list of detector names (letters, digits, underscores, hyphens). Refusing to run rather than passing it through."
+            exit 1
+          fi
+          args="$args --exclude-detectors=$EXCLUDE_DETECTORS"
+          echo "::notice::TruffleHog detectors disabled for this repository: $EXCLUDE_DETECTORS"
+        fi
+        echo "extra_args=$args" >> "$GITHUB_OUTPUT"
+
     - name: TruffleHog 🐽 scanning
       uses: trufflesecurity/trufflehog@main
       with:
-        extra_args: --results=verified
+        extra_args: ${{ steps.trufflehog_args.outputs.extra_args }}

--- a/test_scans/lob_false_positive_example.py
+++ b/test_scans/lob_false_positive_example.py
@@ -1,0 +1,23 @@
+"""A deliberate false positive, kept so the fix for issue #44 stays verifiable.
+
+TruffleHog's Lob detector matches `test_` followed by 35 word characters, which is
+the shape of a Lob test-mode key. The function name below is exactly that shape, so
+scanning this directory reports a *verified* Lob credential even though no
+credential exists anywhere in this repository.
+
+Reproduce the finding, as the action invokes TruffleHog:
+
+    trufflehog filesystem test_scans --results=verified --json
+
+And confirm the input added for #44 suppresses only that detector:
+
+    trufflehog filesystem test_scans --results=verified --exclude-detectors=lob --json
+
+The window the detector matches can also span an identifier and the text after it,
+so a 39-character name plus one following character matches too - which is why the
+answer is a detector exclusion rather than a naming convention.
+"""
+
+
+def test_alpha_beta_gamma_delta_epsilon_zeta():
+    assert True


### PR DESCRIPTION
Closes #44.

## The gap

A TruffleHog detector that cannot apply to a repository has no local remedy today. The action
exposes `github_token`, `gitleaks_license` and `gitleaks_regex_internal_url` — all of which feed
gitleaks — so a TruffleHog false positive can only be worked around by editing the code it matches.

The detector that prompted #44 is `Lob`: it matches `test_` followed by 35 word characters, the
shape of a Lob test key. Because the action passes `--results=verified`, the finding arrives
labelled as a **confirmed live credential**. Ordinary Python test names reach that shape.

The cost isn't the failed build. It's that a class of reliably false *verified* findings teaches
people to skip the investigation the verified flag exists to trigger.

## The change

One new optional input, empty by default — so behaviour is unchanged for every existing consumer.

```yaml
- uses: hmcts/secrets-scanner@v1
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    gitleaks_license: ${{ secrets.GITLEAKS_LICENSE }}
    trufflehog_exclude_detectors: lob
```

## Three deliberate limits, and why

**Detector names only, validated.** The input accepts letters, digits, underscores, commas and
hyphens; anything else fails the step with a clear message. Without that check this becomes a
general argument passthrough, and `--no-verification` or `--results=all` could quietly weaken the
gate through an input that reads like a narrow one. Exercised against `lob --no-verification`,
`lob; rm -rf /` and a command substitution — each exits non-zero without composing arguments.

**The value reaches the shell via the environment, not interpolation.** An input interpolated
directly into a `run:` block is a command-injection seam, and this is a security control.

**gitleaks is untouched**, as #44 asked — anything the other scanner catches is still caught.

Every exclusion stays reviewable: it sits in the caller's workflow file, and the run log carries a
`::notice::` naming the detectors disabled.

## Verification

`test_scans/lob_false_positive_example.py` carries the reproduction so this stays checkable.

| Invocation | Verified findings |
|---|---|
| `--results=verified` (today) | 1 |
| `--results=verified --exclude-detectors=lob` | 0 |
| input empty | unchanged — `--results=verified` |

Composed-argument output was also checked directly for empty, single and multiple detector values.

## Deliberately not included

The TruffleHog step uses `trufflesecurity/trufflehog@main` rather than a release tag, so detector
behaviour can change between two runs of an unchanged pull request — #44 notes this too. Pinning
would make results reproducible, but it also stops detector *fixes* arriving automatically. That's
a trade-off for the owners to make rather than a drive-by change here.
