### PR TITLE
Require detector exclusions to name the paths they apply to

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,16 @@ jobs:
 | `github_token` | yes | — | Token for repository access and comments |
 | `gitleaks_license` | yes | — | Licensed gitleaks |
 | `gitleaks_regex_internal_url` | no | `""` | Regex identifying internal URLs, added to the gitleaks rules |
-| `trufflehog_exclude_detectors` | no | `""` | Comma-separated TruffleHog detectors to disable for this repository |
+| `trufflehog_exclude_detectors` | no | `""` | Comma-separated TruffleHog detectors to disable. Requires the input below |
+| `trufflehog_exclude_detectors_in` | no | `""` | Paths the exclusion applies to, one regex per line. Everything else is still scanned by every detector |
 
-### Disabling a TruffleHog detector
+### Disabling a TruffleHog detector, within named paths
 
-Some detectors match strings that cannot be credentials in a given repository. The
-clearest example: TruffleHog's `Lob` detector matches `test_` followed by 35 word
-characters — the shape of a Lob test key — so an ordinary Python test name is
-reported as a **verified** credential and fails the build (see issue #44).
+Some detectors match strings that cannot be credentials. The clearest example: TruffleHog's `Lob`
+detector matches `test_` followed by 35 word characters, so an ordinary Python test name is reported
+as a **verified** credential and fails the build (issue #44).
 
-Where a provider genuinely does not apply, a repository can turn that detector off
-without weakening the rest of the scan:
+A detector can be disabled **within paths you name**, never repository-wide:
 
 ```yaml
 - uses: hmcts/secrets-scanner@v1
@@ -82,19 +81,30 @@ without weakening the rest of the scan:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     gitleaks_license: ${{ secrets.GITLEAKS_LICENSE }}
     trufflehog_exclude_detectors: lob
+    trufflehog_exclude_detectors_in: |
+      (^|/)tests?/
+      (^|/)test_scans/
 ```
 
-Two deliberate limits:
+`trufflehog_exclude_detectors` on its own **fails the run**. That is deliberate: turning a detector
+off everywhere means a credential introduced later in application code goes unreported, and nothing
+in the run says so. Naming the paths keeps the dismissal where the false positive lives.
 
-- **Detector names only.** The input accepts letters, digits, underscores, commas
-  and hyphens, and the action fails if given anything else. That is what stops it
-  becoming a general argument passthrough, through which `--no-verification` or
-  `--results=all` could quietly weaken the gate.
-- **gitleaks is untouched.** Only TruffleHog's detector set changes, so a secret
-  the other scanner would catch is still caught.
+How it works: TruffleHog runs twice. Once over everything *outside* those paths with every detector
+enabled, and once over the paths themselves with the named detectors off. Either run failing fails
+the job, so a real credential in application code is still caught while the test fixture is not
+reported.
 
-Each exclusion is visible in the workflow file and echoed as a notice in the run
-log, so it stays reviewable rather than becoming invisible configuration.
+Two further limits:
+
+- **Detector names only.** The input accepts letters, digits, underscores, commas and hyphens, and
+  the action fails otherwise. That is what stops it becoming a general argument passthrough, through
+  which `--no-verification` or `--results=all` could quietly weaken the gate.
+- **gitleaks is untouched.** Only TruffleHog's detector set changes, so anything the other scanner
+  catches is still caught.
+
+Each exclusion is visible in the caller's workflow file, the scope is printed in the run log, and a
+notice names the detectors disabled and where.
 
 ## 🔄 Keeping Up to Date
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,18 @@ inputs:
     required: false
     default: ""
     description: >
-      Comma-separated TruffleHog detectors to disable for this repository, e.g.
-      "lob" for a provider it does not use. Affects TruffleHog only; gitleaks is
-      unchanged. Accepts letters, digits, underscores, commas and hyphens only, so
-      this input cannot be used to pass other arguments to the scanner.
+      Comma-separated TruffleHog detectors to disable, e.g. "lob". Requires
+      trufflehog_exclude_detectors_in - a detector cannot be disabled repository-wide,
+      only within named paths. Affects TruffleHog only; gitleaks is unchanged. Accepts
+      letters, digits, underscores, commas and hyphens only, so this input cannot be
+      used to pass other arguments to the scanner.
+  trufflehog_exclude_detectors_in:
+    required: false
+    default: ""
+    description: >
+      Where trufflehog_exclude_detectors applies, as one regex per line matching
+      paths, e.g. "(^|/)tests?/". Everything outside these paths is still scanned by
+      every detector, so a credential introduced in application code is still caught.
 
 runs:
   using: "composite"
@@ -48,27 +56,76 @@ runs:
       id: trufflehog_args
       shell: bash
       env:
-        # Passed through the environment rather than interpolated into the script:
-        # a workflow input reaching a shell directly is a command-injection seam,
+        # Through the environment rather than interpolated into the script: a
+        # workflow input reaching a shell directly is a command-injection seam,
         # and this action is a security control.
         EXCLUDE_DETECTORS: ${{ inputs.trufflehog_exclude_detectors }}
+        EXCLUDE_DETECTORS_IN: ${{ inputs.trufflehog_exclude_detectors_in }}
       run: |
         set -euo pipefail
-        args="--results=verified"
-        if [ -n "$EXCLUDE_DETECTORS" ]; then
-          # Detector names only. Without this check a caller could append arbitrary
-          # flags - --no-verification, or --results=all - and weaken the scan
-          # through an input that reads like a narrow one.
-          if ! printf '%s' "$EXCLUDE_DETECTORS" | grep -Eq '^[A-Za-z0-9_,-]+$'; then
-            echo "::error::trufflehog_exclude_detectors must be a comma-separated list of detector names (letters, digits, underscores, hyphens). Refusing to run rather than passing it through."
+        base="--results=verified"
+
+        # Each output key is written exactly once. Writing `scoped` twice and relying
+        # on the later value winning is the kind of thing that behaves differently in
+        # the runner than in a shell.
+        if [ -z "$EXCLUDE_DETECTORS" ]; then
+          if [ -n "$EXCLUDE_DETECTORS_IN" ]; then
+            echo "::error::trufflehog_exclude_detectors_in was given without trufflehog_exclude_detectors, so it would do nothing. Remove it, or name the detectors to disable."
             exit 1
           fi
-          args="$args --exclude-detectors=$EXCLUDE_DETECTORS"
-          echo "::notice::TruffleHog detectors disabled for this repository: $EXCLUDE_DETECTORS"
+          {
+            echo "scoped=false"
+            echo "base_args=$base"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
         fi
-        echo "extra_args=$args" >> "$GITHUB_OUTPUT"
 
+        # Detector names only. Without this check a caller could append arbitrary
+        # flags - --no-verification, or --results=all - and weaken the scan through
+        # an input that reads like a narrow one.
+        if ! printf '%s' "$EXCLUDE_DETECTORS" | grep -Eq '^[A-Za-z0-9_,-]+$'; then
+          echo "::error::trufflehog_exclude_detectors must be a comma-separated list of detector names (letters, digits, underscores, hyphens). Refusing to run rather than passing it through."
+          exit 1
+        fi
+
+        # A detector cannot be turned off repository-wide. Disabling one everywhere
+        # means a credential introduced later in application code goes unreported,
+        # and nothing in the run says so. Naming the paths keeps the dismissal where
+        # the false positive is - usually test fixtures - and leaves the rest of the
+        # tree scanned by everything.
+        if [ -z "$EXCLUDE_DETECTORS_IN" ]; then
+          echo "::error::trufflehog_exclude_detectors requires trufflehog_exclude_detectors_in. A detector can be disabled within named paths, not repository-wide: set trufflehog_exclude_detectors_in to the paths the false positive lives in, for example '(^|/)tests?/'."
+          exit 1
+        fi
+
+        scope="$GITHUB_WORKSPACE/.trufflehog-exclusion-scope"
+        printf '%s\n' "$EXCLUDE_DETECTORS_IN" > "$scope"
+        echo "----- detector exclusion is scoped to these paths -----"
+        cat "$scope"
+        echo "::notice::TruffleHog detectors $EXCLUDE_DETECTORS are disabled only within the paths listed in .trufflehog-exclusion-scope; the rest of the tree is scanned by every detector."
+        {
+          echo "scoped=true"
+          echo "outside_args=$base --exclude-paths=.trufflehog-exclusion-scope"
+          echo "inside_args=$base --include-paths=.trufflehog-exclusion-scope --exclude-detectors=$EXCLUDE_DETECTORS"
+        } >> "$GITHUB_OUTPUT"
+
+    # One run when nothing is excluded - the original behaviour, unchanged.
     - name: TruffleHog 🐽 scanning
+      if: ${{ steps.trufflehog_args.outputs.scoped != 'true' }}
       uses: trufflesecurity/trufflehog@main
       with:
-        extra_args: ${{ steps.trufflehog_args.outputs.extra_args }}
+        extra_args: ${{ steps.trufflehog_args.outputs.base_args }}
+
+    # Two runs when a detector is excluded within named paths, so the exclusion
+    # cannot reach the rest of the tree. Both steps fail the job on a finding.
+    - name: TruffleHog 🐽 scanning (outside the exclusion scope, all detectors)
+      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' }}
+      uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: ${{ steps.trufflehog_args.outputs.outside_args }}
+
+    - name: TruffleHog 🐽 scanning (inside the exclusion scope)
+      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' }}
+      uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: ${{ steps.trufflehog_args.outputs.inside_args }}


### PR DESCRIPTION
Follow-up to #45, which is merged. Refs #44.

## The hole #45 left

#45 let a detector be turned off for a whole repository. That is more than the false positive needs,
and it leaves a gap worth closing: with `lob` disabled repository-wide, a Lob credential **introduced
later in application code** goes unreported, and nothing in the run says so.

The dismissal belongs where the false positive is — test fixtures — not everywhere.

## The change

`trufflehog_exclude_detectors` now **requires** `trufflehog_exclude_detectors_in`:

```yaml
- uses: hmcts/secrets-scanner@v1
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    gitleaks_license: ${{ secrets.GITLEAKS_LICENSE }}
    trufflehog_exclude_detectors: lob
    trufflehog_exclude_detectors_in: |
      (^|/)tests?/
```

Detectors without paths **fails the run**, with a message saying what to set. The narrow behaviour is
the only behaviour rather than the recommended one.

Implemented as two TruffleHog runs: one over everything *outside* those paths with every detector
enabled, one over the paths themselves with the named detectors off. Either failing fails the job.
With no exclusion configured there is a single run with exactly the previous arguments.

## Verified

Fixtures: a 40-character test name in `tests/sample_test.py`, and a Lob-shaped value in `src/app.py`.

| Run | `src/app.py` | `tests/sample_test.py` |
|---|---|---|
| Today (single run) | reported | reported → build fails on a test name |
| Scoped, outside the paths | **reported** | not scanned |
| Scoped, inside the paths | not scanned | not reported |

So a credential in application code is still caught, and the test fixture is not. The compose step
was exercised across every input combination: neither input, both, detectors without paths, paths
without detectors, and `lob --no-verification` smuggled through the detector list — the last three
exit non-zero without composing arguments.

## Why now

The floating `v1` tag does **not** yet include #45 (`v1` → `65bb19a7`; the input landed in `v1.2.1`),
and code search finds no consuming repository passing the input. So tightening this from optional to
required breaks nothing today. That window closes as soon as `v1` moves.

## One thing not verified

The scope file is written to `$GITHUB_WORKSPACE` and passed as a **relative** path, on the assumption
the upstream action resolves it against the workspace inside its container. I could not test that
here — this repository has no CI — so it wants one trial run in a consuming repository before `v1`
moves. If the path does not resolve, the symptom is TruffleHog scanning everything in both runs
rather than silently skipping, which fails safe.
