### PR TITLE
Allow an individual finding to be retired by fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ jobs:
 | `gitleaks_regex_internal_url` | no | `""` | Regex identifying internal URLs, added to the gitleaks rules |
 | `trufflehog_exclude_detectors` | no | `""` | Comma-separated TruffleHog detectors to disable. Requires the input below |
 | `trufflehog_exclude_detectors_in` | no | `""` | Paths the exclusion applies to, one regex per line. Everything else is still scanned by every detector |
+| `trufflehog_allowlist` | no | `""` | Path to a file retiring individual findings by fingerprint, for false positives no path can reach |
 
 ### Disabling a TruffleHog detector, within named paths
 
@@ -105,6 +106,54 @@ Two further limits:
 
 Each exclusion is visible in the caller's workflow file, the scope is printed in the run log, and a
 notice names the detectors disabled and where.
+
+### Retiring a single finding, where no path can reach it
+
+Path scoping cannot cover everything. **TruffleHog scans commit messages as well as files, and a
+commit message has no path** — so a false positive in one cannot be scoped away, and a repository-wide
+exclusion is refused above. That combination left such a finding with no lever at all (issue #47).
+
+`trufflehog_allowlist` names a file that retires findings one at a time:
+
+```yaml
+- uses: hmcts/secrets-scanner@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    gitleaks_license: ${{ secrets.GITLEAKS_LICENSE }}
+    trufflehog_allowlist: .trufflehog-allowlist
+```
+
+```
+# .trufflehog-allowlist
+# <64-hex fingerprint>  <reason>
+e36cba747a9c3e178a5a42241bb2742abc6e3d29aaad762ccc6408bd97e2726e  Test method name quoted in a commit message, not a Lob key
+```
+
+**Getting a fingerprint:** you do not compute it. Every finding that is not allowlisted is printed
+with its fingerprint, so a failing run tells you exactly what to paste.
+
+A fingerprint is the SHA-256 of the detector name and the matched text. It carries no location, which
+has two consequences worth knowing: the same string quoted in four commits is **one** entry rather
+than four, and an entry keeps working when a file moves or history is rewritten.
+
+What keeps this narrow:
+
+- **One finding, not a detector or a directory.** A fingerprint matches one specific detector-plus-text
+  pair. There is no wildcard, so this cannot become an off-switch.
+- **A reason is mandatory.** An entry without one fails the run, because the next reader has to be able
+  to judge it.
+- **Stale entries are reported.** An entry matching nothing raises a warning — either the false
+  positive is gone and the line should go, or what it described has changed shape. An unpruned
+  allowlist is how a scanner goes quietly blind.
+- **A malformed allowlist fails the run** rather than being skipped, so a typo can never read as
+  "nothing to report".
+- **The matched text is never printed.** This path runs over real findings too, and a build log is a
+  durable, widely readable place for a live credential to end up.
+
+One trade-off to be aware of: with an allowlist set, the action runs TruffleHog itself instead of
+delegating to `trufflesecurity/trufflehog`, because that action fails the step on any finding and
+exposes no results to inspect — there is nowhere to apply a per-finding decision. Same image, same
+arguments, plus `--json`. Callers with no allowlist are on the original path, unchanged.
 
 ## 🔄 Keeping Up to Date
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,17 @@ inputs:
       Where trufflehog_exclude_detectors applies, as one regex per line matching
       paths, e.g. "(^|/)tests?/". Everything outside these paths is still scanned by
       every detector, so a credential introduced in application code is still caught.
+  trufflehog_allowlist:
+    required: false
+    default: ""
+    description: >
+      Path to a file retiring individual TruffleHog findings by fingerprint, one per
+      line as "<64-hex fingerprint>  <reason>". Use this where a path-scoped detector
+      exclusion cannot reach - most importantly a false positive in a commit message,
+      which has no path. The fingerprint identifies one finding, so this cannot disable
+      a detector or a directory; every entry must give a reason; and an entry that
+      matches nothing is reported, because an unpruned allowlist becomes blindness.
+      Unset by default, and the scan behaves exactly as before when unset.
 
 runs:
   using: "composite"
@@ -109,9 +120,13 @@ runs:
           echo "inside_args=$base --include-paths=.trufflehog-exclusion-scope --exclude-detectors=$EXCLUDE_DETECTORS"
         } >> "$GITHUB_OUTPUT"
 
+    # Without an allowlist the upstream action runs as it always has, and decides
+    # pass or fail itself. That is the path almost every caller takes, so it is
+    # left exactly as it was.
+
     # One run when nothing is excluded - the original behaviour, unchanged.
     - name: TruffleHog 🐽 scanning
-      if: ${{ steps.trufflehog_args.outputs.scoped != 'true' }}
+      if: ${{ steps.trufflehog_args.outputs.scoped != 'true' && inputs.trufflehog_allowlist == '' }}
       uses: trufflesecurity/trufflehog@main
       with:
         extra_args: ${{ steps.trufflehog_args.outputs.base_args }}
@@ -119,13 +134,69 @@ runs:
     # Two runs when a detector is excluded within named paths, so the exclusion
     # cannot reach the rest of the tree. Both steps fail the job on a finding.
     - name: TruffleHog 🐽 scanning (outside the exclusion scope, all detectors)
-      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' }}
+      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' && inputs.trufflehog_allowlist == '' }}
       uses: trufflesecurity/trufflehog@main
       with:
         extra_args: ${{ steps.trufflehog_args.outputs.outside_args }}
 
     - name: TruffleHog 🐽 scanning (inside the exclusion scope)
-      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' }}
+      if: ${{ steps.trufflehog_args.outputs.scoped == 'true' && inputs.trufflehog_allowlist == '' }}
       uses: trufflesecurity/trufflehog@main
       with:
         extra_args: ${{ steps.trufflehog_args.outputs.inside_args }}
+
+    # With an allowlist the scan has to be run here rather than delegated, because
+    # the upstream action fails the step on any finding and exposes no results to
+    # inspect - there is nowhere to apply a per-finding decision. Same image, same
+    # arguments; the only differences are --json, and that the verdict is made by
+    # the filter instead of by exit code alone.
+    - name: TruffleHog 🐽 scanning (allowlist applied per finding)
+      if: ${{ inputs.trufflehog_allowlist != '' }}
+      shell: bash
+      env:
+        # Through the environment, not interpolated: see the note above.
+        ALLOWLIST: ${{ inputs.trufflehog_allowlist }}
+        SCOPED: ${{ steps.trufflehog_args.outputs.scoped }}
+        BASE_ARGS: ${{ steps.trufflehog_args.outputs.base_args }}
+        OUTSIDE_ARGS: ${{ steps.trufflehog_args.outputs.outside_args }}
+        INSIDE_ARGS: ${{ steps.trufflehog_args.outputs.inside_args }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        # A path, not a shell fragment. Refuse rather than pass it through.
+        if ! printf '%s' "$ALLOWLIST" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+          echo "::error::trufflehog_allowlist must be a plain relative path (letters, digits, dot, underscore, hyphen, slash). Refusing to run rather than passing it through."
+          exit 1
+        fi
+        case "$ALLOWLIST" in
+          /*|*..*) echo "::error::trufflehog_allowlist must be a relative path inside the repository, with no '..' segments."; exit 1 ;;
+        esac
+        if [ ! -f "$GITHUB_WORKSPACE/$ALLOWLIST" ]; then
+          echo "::error::trufflehog_allowlist names $ALLOWLIST, which is not a file in this repository."
+          exit 1
+        fi
+
+        image="ghcr.io/trufflesecurity/trufflehog:latest"
+        docker pull -q "$image"
+
+        findings="$RUNNER_TEMP/trufflehog-findings.json"
+        : > "$findings"
+
+        scan() {
+          # --no-fail because the verdict belongs to the filter: a finding that is
+          # allowlisted must not fail the job, and exit code alone cannot say which.
+          # shellcheck disable=SC2086
+          docker run --rm -v "$GITHUB_WORKSPACE:/pwd" -w /pwd "$image" \
+            git file:///pwd $1 --json --no-fail >> "$findings"
+        }
+
+        if [ "$SCOPED" = "true" ]; then
+          scan "$OUTSIDE_ARGS"
+          scan "$INSIDE_ARGS"
+        else
+          scan "$BASE_ARGS"
+        fi
+
+        python3 "$ACTION_PATH/scripts/filter-allowlisted-findings.py" \
+          --allowlist "$GITHUB_WORKSPACE/$ALLOWLIST" < "$findings"

--- a/scripts/filter-allowlisted-findings.py
+++ b/scripts/filter-allowlisted-findings.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Retire an individual TruffleHog finding by fingerprint, and nothing wider.
+
+TruffleHog has no baseline or ignore mechanism of its own: the levers it ships
+are per-detector, per-path and per-entropy. All three are blunter than the
+problem. A false positive in a *commit message* has no path at all, so it cannot
+be scoped away, and turning a detector off repository-wide is exactly what this
+action refuses to allow.
+
+So the unit here is one finding. A fingerprint is the SHA-256 of the detector
+name and the matched text, which is stable across runs and across commits - the
+same string quoted in four commit messages is one fingerprint, not four - and
+carries no location, so it does not churn when history is rewritten or a file
+moves.
+
+Two deliberate choices:
+
+  The matched text is never printed. For a false positive it would be harmless,
+  but this same path runs over real findings, and a log is a durable, widely
+  readable place for a live credential to end up. The fingerprint, detector and
+  location are enough to identify and triage one.
+
+  Every entry must carry a reason, and an entry that matches nothing is
+  reported. An allowlist nobody prunes becomes permanent blindness, and the
+  failure is silent by nature: the entry stops corresponding to anything and
+  keeps suppressing whatever it happens to match next.
+
+Reads TruffleHog's JSON-lines output on stdin. Exits 0 when every finding is
+allowlisted, 1 when any is not, and 2 when the allowlist itself is unusable -
+a malformed allowlist must never read as "nothing to report".
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+FINGERPRINT = re.compile(r"^[0-9a-f]{64}$")
+
+
+def fingerprint(detector: str, raw: str) -> str:
+    """Identify a finding by what it is, not where it was found."""
+    return hashlib.sha256(f"{detector}\n{raw}".encode()).hexdigest()
+
+
+def parse_allowlist(path: pathlib.Path) -> dict[str, str]:
+    """Fingerprint -> reason. Raises ValueError on anything it cannot trust."""
+    entries: dict[str, str] = {}
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        text = line.strip()
+        if not text or text.startswith("#"):
+            continue
+        parts = text.split(maxsplit=1)
+        if not FINGERPRINT.match(parts[0]):
+            raise ValueError(
+                f"{path}:{number}: expected a 64-character hex fingerprint, got {parts[0]!r}. "
+                "The fingerprint is printed beside every unallowlisted finding - copy it from there."
+            )
+        if len(parts) == 1 or not parts[1].strip():
+            raise ValueError(
+                f"{path}:{number}: fingerprint {parts[0][:12]}… has no reason. "
+                "Every entry must say why it is here, or the next reader cannot judge it."
+            )
+        if parts[0] in entries:
+            raise ValueError(f"{path}:{number}: fingerprint {parts[0][:12]}… is listed twice.")
+        entries[parts[0]] = parts[1].strip()
+    return entries
+
+
+def location(finding: dict) -> str:
+    """Where the finding was seen. Commit-message findings carry no file."""
+    git = finding.get("SourceMetadata", {}).get("Data", {}).get("Git", {})
+    commit = (git.get("commit") or "")[:8]
+    path = git.get("file")
+    where = f"{path}:{git.get('line', '?')}" if path else "commit message (no file)"
+    return f"{where}  commit {commit}" if commit else where
+
+
+def read_findings(stream) -> list[dict]:
+    """One JSON object per line; TruffleHog also emits log lines, so skip those."""
+    findings = []
+    for line in stream:
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("DetectorName"):
+            findings.append(record)
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--allowlist", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+
+    if not args.allowlist.is_file():
+        print(
+            f"::error::trufflehog_allowlist points at {args.allowlist}, which does not exist. "
+            "Refusing to run rather than scanning with an allowlist nobody can read.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        allowed = parse_allowlist(args.allowlist)
+    except (ValueError, OSError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 2
+
+    findings = read_findings(sys.stdin)
+    suppressed: dict[str, int] = {}
+    remaining: list[dict] = []
+
+    for finding in findings:
+        key = fingerprint(finding["DetectorName"], finding.get("Raw", ""))
+        if key in allowed:
+            suppressed[key] = suppressed.get(key, 0) + 1
+        else:
+            remaining.append((key, finding))
+
+    if suppressed:
+        print(f"----- {sum(suppressed.values())} finding(s) retired by the allowlist -----")
+        for key, count in suppressed.items():
+            print(f"  {key[:16]}…  x{count}  {allowed[key]}")
+
+    stale = sorted(set(allowed) - set(suppressed))
+    if stale:
+        print(f"----- {len(stale)} allowlist entry(ies) matched nothing -----")
+        for key in stale:
+            print(f"  {key[:16]}…  {allowed[key]}")
+        print(
+            "::warning::Some allowlist entries matched no finding. Either the false positive is "
+            "gone and the entry should be deleted, or the thing it described has changed shape - "
+            "both are worth a look, because a stale entry silently suppresses whatever it matches next."
+        )
+
+    if remaining:
+        print(f"----- {len(remaining)} finding(s) NOT allowlisted -----")
+        for key, finding in remaining:
+            print(f"  {finding['DetectorName']}  {location(finding)}")
+            print(f"    fingerprint: {key}")
+        print(
+            "::error::TruffleHog reported findings that are not in the allowlist. Treat each as real "
+            "until shown otherwise. If one is a false positive, add its fingerprint above to the "
+            "allowlist file with a reason. The matched text is deliberately not printed here."
+        )
+        return 1
+
+    print(f"No unallowlisted findings ({len(findings)} reported, {sum(suppressed.values())} retired).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-filter-allowlisted-findings.sh
+++ b/scripts/test-filter-allowlisted-findings.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Behaviour tests for filter-allowlisted-findings.py.
+#
+# The exit codes carry the meaning, so they are what is asserted: 0 lets a build
+# through, 1 fails it on a finding, and 2 refuses on an allowlist that cannot be
+# trusted. Getting 2 wrong is the dangerous one - a malformed allowlist that
+# exited 0 would read as "nothing to report".
+#
+# No network, no docker: the input is a fixture in TruffleHog's JSON-lines shape.
+# Run: scripts/test-filter-allowlisted-findings.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+filter="$here/filter-allowlisted-findings.py"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Two findings sharing one detector and matched text - one in a file, one in a
+# commit message (no `file` key at all, which is the case path scoping cannot
+# reach) - plus a second, different finding.
+cat > "$work/findings.json" <<'JSON'
+{"SourceMetadata":{"Data":{"Git":{"commit":"1111111111111111111111111111111111111111","file":"tests/test_thing.py","line":12}}},"DetectorName":"Lob","Raw":"test_a_name_long_enough_to_look_like_a_key","Verified":true}
+{"SourceMetadata":{"Data":{"Git":{"commit":"2222222222222222222222222222222222222222","line":3}}},"DetectorName":"Lob","Raw":"test_a_name_long_enough_to_look_like_a_key","Verified":true}
+{"SourceMetadata":{"Data":{"Git":{"commit":"3333333333333333333333333333333333333333","file":"src/app.py","line":7}}},"DetectorName":"Stripe","Raw":"sk_live_pretend_value_for_the_test","Verified":true}
+JSON
+
+fp() { python3 -c "import hashlib,sys;print(hashlib.sha256((sys.argv[1]+chr(10)+sys.argv[2]).encode()).hexdigest())" "$1" "$2"; }
+LOB=$(fp Lob test_a_name_long_enough_to_look_like_a_key)
+STRIPE=$(fp Stripe sk_live_pretend_value_for_the_test)
+
+pass=0 fail=0
+check() { # check <name> <expected-exit> <allowlist-file>
+  out=$(python3 "$filter" --allowlist "$3" < "$work/findings.json" 2>&1); code=$?
+  if [ "$code" = "$2" ]; then pass=$((pass+1)); printf '  ok    %-58s exit %s\n' "$1" "$code"
+  else fail=$((fail+1)); printf '  FAIL  %-58s exit %s, wanted %s\n%s\n' "$1" "$code" "$2" "$out"; fi
+  printf '%s' "$out" > "$work/last.out"
+}
+
+echo "one fingerprint covers both a file and a commit-message occurrence"
+printf '%s  known false positive\n' "$LOB" > "$work/lob-only"
+check "unrelated finding still fails the build" 1 "$work/lob-only"
+grep -q 'Stripe' "$work/last.out" || { echo "  FAIL  the surviving finding was not named"; fail=$((fail+1)); }
+grep -q 'sk_live_pretend_value_for_the_test' "$work/last.out" && { echo "  FAIL  matched text leaked into output"; fail=$((fail+1)); } || pass=$((pass+1))
+
+printf '%s  known false positive\n%s  accepted for this test\n' "$LOB" "$STRIPE" > "$work/both"
+check "every finding allowlisted, build passes" 0 "$work/both"
+
+echo "an allowlist that cannot be trusted must refuse, never pass"
+printf 'nonsense  a reason\n' > "$work/bad-fp"
+check "fingerprint that is not 64 hex characters" 2 "$work/bad-fp"
+printf '%s\n' "$LOB" > "$work/no-reason"
+check "entry with no reason" 2 "$work/no-reason"
+printf '%s  one\n%s  two\n' "$LOB" "$LOB" > "$work/dupe"
+check "same fingerprint listed twice" 2 "$work/dupe"
+check "allowlist file that does not exist" 2 "$work/absent"
+
+echo "a stale entry is reported, but does not fail the build"
+printf '%s  known false positive\n%s  accepted for this test\n%s  long gone\n' \
+  "$LOB" "$STRIPE" "$(fp Stripe sk_live_no_longer_present)" > "$work/stale"
+check "stale entry warns only" 0 "$work/stale"
+grep -q 'matched nothing' "$work/last.out" && pass=$((pass+1)) || { echo "  FAIL  stale entry not reported"; fail=$((fail+1)); }
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #47.

## The gap this closes

Path scoping cannot cover everything. **TruffleHog scans commit messages as well as files, and a commit message has no path** — so a false positive in one cannot be scoped away. #46 rightly refuses a repository-wide exclusion. Together those left such a finding with **no lever at all**.

Demonstrated rather than argued. Scanning a consumer repository and inspecting the raw JSON, 20 findings came back: 19 carry a `file` key, and one carries **no `file` key at all** — the pathless commit-message case.

## Checked first: TruffleHog has no mechanism for this

Before designing anything I went through `trufflehog --help` and `trufflehog git --help` on 3.96.0. The levers it ships are `--exclude-detectors`, `--include-paths`/`--exclude-paths`, `--exclude-globs`, `--filter-entropy` and `--results`. **There is no baseline, ignore-file or fingerprint mechanism.** All three of its filters are blunter than the problem, so the allowlist has to be ours.

## The design

The unit is **one finding**, identified by `SHA-256(detector name + matched text)`.

That deliberately carries no location, and two useful things follow: the same string quoted in four commit messages is **one** entry rather than four, and an entry keeps working when a file moves or history is rewritten.

What keeps it narrow — the property #46 was protecting:

- **One detector-and-text pair, no wildcard.** It cannot become an off-switch for a detector or a directory.
- **A reason is mandatory**; an entry without one fails the run.
- **Stale entries are reported.** An entry matching nothing warns — an unpruned allowlist is how a scanner goes quietly blind.
- **A malformed allowlist fails the run** rather than being skipped, so a typo can never read as "nothing to report".
- **The matched text is never printed.** For a false positive that is harmless, but this path runs over real findings too, and a build log is a durable, widely readable place for a live credential to end up. The fingerprint is printed beside every unallowlisted finding, so a failing run says exactly what to paste — nobody has to compute one.

## Verified, with mutation testing

`scripts/test-filter-allowlisted-findings.sh` asserts behaviour by exit code, since that is what carries the meaning: **0** passes, **1** fails on a finding, **2** refuses an allowlist it cannot trust. Getting 2 wrong is the dangerous one.

9 assertions pass, covering: one fingerprint matching both a file and a commit-message occurrence; an unrelated finding still failing the build; the matched text not leaking; a non-hex fingerprint, a missing reason, a duplicate entry and a missing file each refusing; and a stale entry warning without failing.

**Mutation-tested, because a green suite only proves it runs:**

| Mutation | Result |
|---|---|
| force every exit to `0` | 5 of 9 fail |
| ignore the allowlist entirely | 2 of 9 fail |
| restored | 9 pass |

## Trade-off, stated plainly

With an allowlist set, the action runs TruffleHog itself instead of delegating to `trufflesecurity/trufflehog`, because that action fails the step on any finding and exposes no results to inspect — there is nowhere to apply a per-finding decision. Same image, same arguments, plus `--json`.

**Callers with no allowlist are on the original code path, unchanged.** This is additive.

## Not tagged

No version bump or tag here — releases are yours to cut.